### PR TITLE
Font-Awesome Fix and Caching

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>UCF Search</title>
     <script type="text/javascript" id="ucfhb-script" src="//universityheader.ucf.edu/bar/js/university-header.js?use-1200-breakpoint=1"></script>
-    <!-- In public/index.html <head> -->
     <script src="https://kit.fontawesome.com/850d323291.js" crossorigin="anonymous"></script>
   </head>
   <body>

--- a/index.html
+++ b/index.html
@@ -6,6 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>UCF Search</title>
     <script type="text/javascript" id="ucfhb-script" src="//universityheader.ucf.edu/bar/js/university-header.js?use-1200-breakpoint=1"></script>
+    <!-- In public/index.html <head> -->
+    <script src="https://kit.fontawesome.com/850d323291.js" crossorigin="anonymous"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0",
       "dependencies": {
         "@awesome.me/kit-850d323291": "^1.0.4",
-        "@fortawesome/react-fontawesome": "^3.1.1",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-router-dom": "^7.9.4",
@@ -935,32 +934,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/@fortawesome/fontawesome-svg-core": {
-      "version": "7.1.0",
-      "resolved": "https://npm.fontawesome.com/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-7.1.0.tgz",
-      "integrity": "sha512-fNxRUk1KhjSbnbuBxlWSnBLKLBNun52ZBTcs22H/xEEzM6Ap81ZFTQ4bZBxVQGQgVY0xugKGoRcCbaKjLQ3XZA==",
-      "license": "MIT",
-      "peer": true,
-      "dependencies": {
-        "@fortawesome/fontawesome-common-types": "7.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/@fortawesome/react-fontawesome": {
-      "version": "3.1.1",
-      "resolved": "https://npm.fontawesome.com/@fortawesome/react-fontawesome/-/react-fontawesome-3.1.1.tgz",
-      "integrity": "sha512-EDllr9hpodc21odmUywHS1alXNiCd4E8sp5GJ5s7wYINz8vSmMiNWpALTiuYODb865YyQ/NlyiN4mbXp7HCNqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=20"
-      },
-      "peerDependencies": {
-        "@fortawesome/fontawesome-svg-core": "~6 || ~7",
-        "react": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@humanfs/core": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@awesome.me/kit-850d323291": "^1.0.4",
+
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-router-dom": "^7.9.4",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
   },
   "dependencies": {
     "@awesome.me/kit-850d323291": "^1.0.4",
-    "@fortawesome/react-fontawesome": "^3.1.1",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-router-dom": "^7.9.4",

--- a/src/components/LocationResults.tsx
+++ b/src/components/LocationResults.tsx
@@ -3,9 +3,6 @@ import './LocationResults.scss'
 import { SearchQueryContext } from '../SearchContext';
 import type { LocationResultSet } from '../types/LocationTypes';
 
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { byPrefixAndName } from '@awesome.me/kit-850d323291/icons';
-
 const MAP_SEARCH_URL = import.meta.env.VITE_MAP_SEARCH_URL;
 
 function LocationResults() {
@@ -48,17 +45,17 @@ function LocationResults() {
             return (
               <div key={loc.name}>
                 <h2 className='location-result-heading'>
-                  <FontAwesomeIcon icon={byPrefixAndName.fas['map-location-dot']} className='fa-fw' /> Locations
+                  <i className='fa-solid fa-map-location-dot fa-fw' aria-hidden="true"></i> Locations
                 </h2>
                 <div className='sidebar-result'>
                   <h3 className='location-heading'>{loc.name}</h3>
                   <div className='media pt-1'>
                     <div className='media-body'>
                       <a className='mb-2 d-block' href={loc.profile_link} target="_blank">
-                        <FontAwesomeIcon icon={byPrefixAndName.fas['circle-info']} className='fa-fw mr-1' /> More Information
+                        <i className='fa-solid fa-circle-info fa-fw mr-1' aria-hidden="true"></i> More Information
                       </a>
                       <a className='mb-2 d-block' href={`https://www.google.com/maps/dir/Current+Location/${loc.googlemap_point}`} target='_blank'>
-                        <FontAwesomeIcon icon={byPrefixAndName.fas['location-arrow']} className='fa-fw mr-1' /> Directions
+                        <i className='fa-solid fa-location-arrow fa-fw mr-1' aria-hidden="true"></i> Directions
                       </a>
                     </div>
                   </div>

--- a/src/components/LocationResults.tsx
+++ b/src/components/LocationResults.tsx
@@ -51,10 +51,10 @@ function LocationResults() {
                   <h3 className='location-heading'>{loc.name}</h3>
                   <div className='media pt-1'>
                     <div className='media-body'>
-                      <a className='mb-2 d-block' href={loc.profile_link} target="_blank">
+                      <a className='mb-2 d-block' href={loc.profile_link} target="_blank" rel="noopener noreferrer">
                         <i className='fa-solid fa-circle-info fa-fw mr-1' aria-hidden="true"></i> More Information
                       </a>
-                      <a className='mb-2 d-block' href={`https://www.google.com/maps/dir/Current+Location/${loc.googlemap_point}`} target='_blank'>
+                      <a className='mb-2 d-block' href={`https://www.google.com/maps/dir/Current+Location/${loc.googlemap_point}`} target='_blank' rel="noopener noreferrer">
                         <i className='fa-solid fa-location-arrow fa-fw mr-1' aria-hidden="true"></i> Directions
                       </a>
                     </div>

--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -1,0 +1,10 @@
+{
+  "routes": [
+    {
+      "route": "/assets/*.{css,js}",
+      "headers": {
+        "Cache-Control": "public, max-age=31536000, immutable"
+      }
+    }
+  ]
+}

--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -1,7 +1,7 @@
 {
   "routes": [
     {
-      "route": "/assets/*.{css,js}",
+      "route": "/assets/*.{css,js,woff,woff2,ttf,eot,svg,png,jpg,jpeg,gif,webp,ico}",
       "headers": {
         "Cache-Control": "public, max-age=31536000, immutable"
       }


### PR DESCRIPTION
- Removes the FontAwesome react component and just directly loads the kit in the head.
- Replaces the FontAwesome components with `i` elements and the appropriate classes.
- Adds a blanket 1 year local caching rule to all files under `/assets`. For JS and CSS, cache busting occurs as any updates changes the hash in the filename.

Reasons/Motivations:
- When we added the font-awesome react component, the bundled size of our JS asset went from about 250k to 11MB. There are likely ways around this bundle size, but as our use of fonts in this project is extremely simple, I've chosen to handle it the old fashion way.
- Local caching should reduce the amount of requests that make it back to Azure.